### PR TITLE
Add Shako Kabob live demo link, point Portfolio Platform to old.papatenko.org

### DIFF
--- a/apps/dev/src/content/case-studies/shako-kabob-pos.md
+++ b/apps/dev/src/content/case-studies/shako-kabob-pos.md
@@ -3,6 +3,7 @@ title: 'Shako Kabob — Foodtruck POS'
 summary: 'Full-stack point-of-sale and online ordering platform for a food truck, from database schema to automated deploys.'
 tech: ['React', 'Vite', 'Node.js', 'MySQL', 'Docker', 'GitHub Actions', 'Turborepo', 'Coolify']
 repoUrl: 'https://github.com/papatenko/point-of-sale-system'
+demoUrl: 'https://pos.papatenko.org/'
 image: '/images/projects/shako-kabob.png'
 order: 2
 ---

--- a/apps/dev/src/data/projects.ts
+++ b/apps/dev/src/data/projects.ts
@@ -42,6 +42,7 @@ export const projects: Project[] = [
     tech: ['React', 'Vite', 'Node.js', 'MySQL', 'Docker', 'GitHub Actions', 'Turborepo'],
     repo: 'papatenko/point-of-sale-system',
     repoUrl: 'https://github.com/papatenko/point-of-sale-system',
+    demoUrl: 'https://pos.papatenko.org/',
   },
   {
     title: 'Rock Paper Scissors Tournament',
@@ -87,7 +88,7 @@ export const projects: Project[] = [
     tech: ['React', 'CI/CD', 'GitHub Actions', 'Linux', 'Nginx'],
     repo: 'papatenko/portfolio',
     repoUrl: 'https://github.com/papatenko/portfolio',
-    demoUrl: 'https://papatenko.org/',
+    demoUrl: 'https://old.papatenko.org/',
   },
 ];
 


### PR DESCRIPTION
## Summary

- Added a live demo link (`https://pos.papatenko.org/`) to the **Shako Kabob — Foodtruck POS** project card
- Updated the **Portfolio Platform** card's demo link from `papatenko.org` → `https://old.papatenko.org/`
- Added the matching `demoUrl` to the Shako Kabob case-study frontmatter so the case-study page surfaces the live link too (mirrors the existing RPS case study)

## Changes

- `apps/dev/src/data/projects.ts`
- `apps/dev/src/content/case-studies/shako-kabob-pos.md`

## Verification

- `npm run build --workspace apps/dev` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ET84B4RXmBirwv9SdeB6tA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ET84B4RXmBirwv9SdeB6tA)_